### PR TITLE
remove condidtion for stats script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run stats script
-        if: ${{ github.event_name == 'scheduled' || (github.event_name == 'push' && github.ref != 'refs/heads/gh-pages')}}
         run: |
           python bin/get_lesson_stats.py ${{ secrets.PAT_USERNAME }} ${{ secrets.PAT }} > _data/lesson-stats.yml
           git config --local user.email "actions@github.com"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,13 @@ on:
     branches: main
   schedule:
     - cron: '45 */6 * * *'
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Who triggered this build?'
+        required: true
+        default: 'scheduled build'
+
 
 jobs:
   build-website:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run stats script
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           python bin/get_lesson_stats.py ${{ secrets.PAT_USERNAME }} ${{ secrets.PAT }} > _data/lesson-stats.yml
           git config --local user.email "actions@github.com"

--- a/.github/workflows/generate_lesson_stats.yml
+++ b/.github/workflows/generate_lesson_stats.yml
@@ -1,4 +1,4 @@
-name: build and deploy carpentries-incubator.org
+name: Generate Lesson Statistics
 
 on:
   push:


### PR DESCRIPTION
The workflow events listed at the top of the workflow file should properly constrain the entire workflow in the same way. The only constraint I've kept is that the workflow should run on the main branch. 

I've also added a workflow dispatch so that we can run the workflow in a pinch without creating a new commit. 

Note: I'm going to create a fork to try this out. https://github.com/zkamvar/carpentries-incubator.org/actions

This will fix #5 