### PR TITLE
lesson stats: don't commit no changes

### DIFF
--- a/.github/workflows/generate_lesson_stats.yml
+++ b/.github/workflows/generate_lesson_stats.yml
@@ -34,5 +34,5 @@ jobs:
           git config --local user.name "GitHub Actions"
           git pull origin main
           git add _data/lesson-stats.yml
-          git commit --allow-empty -m "[Github Actions] update lesson stats (via ${{ github.sha }})"
+          git commit -m "[Github Actions] update lesson stats (via ${{ github.sha }})" || echo "Nothing to commit"
           git push origin main


### PR DESCRIPTION
There are times when there are no changes to be had in the lesson stats (i.e. https://github.com/carpentries-incubator/carpentries-incubator.org/commit/fd9bdf236bd0523250f9168045b5b1cd421c94d0), for those times, we should not force a commit. This adds the `||` operator to pipe out to a valid command on error.