### PR TITLE
Update "Submit a lesson proposal link" in banner.html

### DIFF
--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -4,7 +4,7 @@
     <div class="col-lg-6 mx-auto">
       <p class="lead mb-4">Design. Develop. Teach. Reflect. Repeat.</p>
       <div class="d-grid gap-2 d-sm-flex justify-content-sm-center">
-        <a href="https://github.com/carpentries-incubator/proposals/issues/new?assignees=&labels=&template=issue_proposal.md"><button type="button" class="btn btn-primary btn-lg px-4 gap-3">Submit a lesson proposal</button></a>
+        <a href="https://github.com/carpentries-incubator/proposals/issues/new?assignees=tobyhodges&labels=proposal&projects=&template=lesson_proposal.yml&title=%5BProposal%5D%3A+"><button type="button" class="btn btn-primary btn-lg px-4 gap-3">Submit a lesson proposal</button></a>
         <a href="https://carpentries.org/community-lessons/"><button type="button" class="btn btn-outline-secondary btn-lg px-4">Browse lessons</button></a>
       </div>
     </div>


### PR DESCRIPTION
When I clicked the big blue "Submit a lesson proposal link" button on carpentries-incubator.org, it brought me to a blank GitHub Issue in the proposals repo.

I know there's a nice Issue template, so I copied the link directly from https://github.com/carpentries-incubator/proposals/issues/new/choose.