### PR TITLE
Update matomo tracking to self-hosted

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -8,12 +8,12 @@
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {
-    var u="https://carpentries.matomo.cloud/";
+    var u="https://matomo.carpentries.org/";
     _paq.push(['setTrackerUrl', u+'matomo.php']);
     _paq.push(['setSiteId', '4']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.src='//cdn.matomo.cloud/carpentries.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
   })();
 </script>
-<noscript><p><img src="https://carpentries.matomo.cloud/matomo.php?idsite=4&amp;rec=1" style="border:0;" alt="" /></p></noscript>
+<noscript><p><img src="https://matomo.carpentries.org/matomo.php?idsite=4&amp;rec=1" style="border:0;" alt="" /></p></noscript>
 <!-- End Matomo Code -->


### PR DESCRIPTION
This PR moves the cloud hosted Matomo tracker to our self-hosted version.